### PR TITLE
Using QSettings to parse desktop files.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,108 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+#core
+  - Regex:           '^<(core)/'
+    Priority:        9
+#components
+  - Regex:           '^<(components)/'
+    Priority:        8
+#gui
+  - Regex:           '^<(gui)/'
+    Priority:        7
+#Qt
+  - Regex:           '^<Q.*'
+    Priority:        5
+#cstd
+  - Regex:           '^<c.*'
+    Priority:        4
+#cstd
+  - Regex:           '^<c.*'
+    Priority:        6
+#system.h
+  - Regex:           '^<.*.h.*'
+    Priority:        2
+#etc
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...
+

--- a/qml-launcher.pro
+++ b/qml-launcher.pro
@@ -1,6 +1,6 @@
 QT += qml quick
 
-CONFIG += c++11
+CONFIG += c++17
 
 SOURCES += src/main.cpp \
     src/imageprovider.cpp \

--- a/src/imageprovider.cpp
+++ b/src/imageprovider.cpp
@@ -1,18 +1,17 @@
 #include "imageprovider.h"
+
 #include <QIcon>
 #include <QDebug>
 
-ImageProvider::ImageProvider() :
-    QQuickImageProvider(QQuickImageProvider::Pixmap)
-{
+ImageProvider::ImageProvider()
+        : QQuickImageProvider(QQuickImageProvider::Pixmap) {
 }
 
-QPixmap ImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &requestedSize)
-{
+QPixmap ImageProvider::requestPixmap(const QString &id, QSize *, const QSize &requestedSize) {
     QIcon icon = QIcon::fromTheme(id);
 
     if (requestedSize.isValid())
         return icon.pixmap(requestedSize);
-    else
-        return icon.pixmap(128,128);
+
+    return icon.pixmap(128, 128);
 }

--- a/src/imageprovider.h
+++ b/src/imageprovider.h
@@ -1,17 +1,9 @@
-#ifndef IMAGEPROVIDER_H
-#define IMAGEPROVIDER_H
+#pragma once
 
 #include <QQuickImageProvider>
 
-class ImageProvider : public QQuickImageProvider
-{
-    public:
-        explicit ImageProvider();
-        QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize);
-
-    signals:
-
-    public slots:
+class ImageProvider : public QQuickImageProvider {
+public:
+    explicit ImageProvider();
+    QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize) final;
 };
-
-#endif // IMAGEPROVIDER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,8 @@ struct AppInfo {
     QString exec;
 };
 
-constexpr auto DESKTOP_FILE_DIR = "/usr/share/applications";
+constexpr auto DESKTOP_FILE_SYSTEM_DIR = "/usr/share/applications";
+constexpr auto DESKTOP_FILE_USER_DIR = "%1/.local/share/applications";
 constexpr auto DESKTOP_ENTRY_STRING = "Desktop Entry";
 
 class SettingsGroupRaii {
@@ -36,8 +37,8 @@ private:
     QSettings &m_settings;
 };
 
-QVariantList apps() {
-    QDirIterator it(DESKTOP_FILE_DIR, {"*.desktop"});
+QVariantList createAppsList(const QString &path) {
+    QDirIterator it(path, {"*.desktop"}, QDir::NoFilter, QDirIterator::Subdirectories);
     QVariantList ret;
 
     while (it.hasNext()) {
@@ -57,6 +58,13 @@ QVariantList apps() {
         ret.append(QStringList{app.name, app.icon, app.exec});
     }
 
+    return ret;
+}
+
+QVariantList apps() {
+    QVariantList ret;
+    ret.append(createAppsList(DESKTOP_FILE_SYSTEM_DIR));
+    ret.append(createAppsList(QString(DESKTOP_FILE_USER_DIR).arg(QDir::homePath())));
     return ret;
 }
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1,7 +1,9 @@
 #include "process.h"
 
-Process::Process(QObject *parent) : QProcess(parent) {
+#include <QDebug>
 
+Process::Process(QObject *parent)
+        : QProcess(parent) {
 }
 
 void Process::start(const QString &program, const QVariantList &arguments) {
@@ -10,8 +12,10 @@ void Process::start(const QString &program, const QVariantList &arguments) {
     qDebug() << "Running" << program;
     // convert QVariantList from QML to QStringList for QProcess
 
-    for (int i = 0; i < arguments.length(); i++)
-        args << arguments[i].toString();
+    for (const auto &arg : arguments)
+        args << arg.toString();
+
+    //unused args
 
     QProcess::startDetached(program);
 }

--- a/src/process.h
+++ b/src/process.h
@@ -1,15 +1,14 @@
 #pragma once
+
 #include <QProcess>
 #include <QVariant>
-#include <QDebug>
 
 class Process : public QProcess {
     Q_OBJECT
 
 public:
-    Process(QObject *parent = 0);
+    Process(QObject *parent = nullptr);
 
-    Q_INVOKABLE void start(const QString &program, const QVariantList &arguments = QVariantList());
-
+    Q_INVOKABLE void start(const QString &program, const QVariantList &arguments = {});
     Q_INVOKABLE QByteArray readAll();
 };


### PR DESCRIPTION
Hi,

I'm working on my highly customized qml launcher (for libretro emulator cores). I'll probably borrow some parts (or ideas) from your project, so there is my small contribution as return with code improvements that I come up while researching your project.

Changes:
* Switched to C++17 standard (most features that I used are available in C++11, maybe all?)
* Added .clang-format configuration, maybe handy for other contributors and for daily work. (It can be configured with QtCreator)
* QSettings is used to parse destkop files.
* Addressed issue #5 and added support for reading destkop files from $HOME/.local/share/applications/. 

Hope I didn't broke something :-).

Cheers,
dev