### PR TITLE
Fix selecting non main monitor & Added check if NoDisplay value in .desktop is true

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -84,6 +84,7 @@ ApplicationWindow {
     }
 
     Component.onCompleted: {
+        x= Qt.application.screens[0].virtualX
         refresh()
         searchField.forceActiveFocus()
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,9 +47,13 @@ QVariantList createAppsList(const QString &path) {
 
         if (!desktopFile.childGroups().contains(DESKTOP_ENTRY_STRING))
             continue;
-
+        
         SettingsGroupRaii raii(desktopFile, DESKTOP_ENTRY_STRING);
 
+        if (desktopFile.contains("NoDisplay"))
+            if (desktopFile.value("NoDisplay").toBool() == 1)
+                continue;
+        
         AppInfo app;
         app.exec = desktopFile.value("Exec").toString().remove("\"").remove(QRegExp(" %."));
         app.icon = desktopFile.value("Icon", "application").toString();


### PR DESCRIPTION
When having multi-monitor setup launcher tends to choose left-most monitor (ak x: 0), did a quick fix on it
Also added check if nodisplay (which hides additional or specified by user app icons)